### PR TITLE
Disabled the CNI bridge networking to use a CNI plugin

### DIFF
--- a/roles/worker/tasks/worker_cert.yaml
+++ b/roles/worker/tasks/worker_cert.yaml
@@ -70,15 +70,15 @@
     dest: /var/lib/kube-proxy/kubeconfig
     mode: '0755'
 
-- name: bridge network
-  template:
-    src: "{{ role_path }}/templates/10-bridge.conf.j2"
-    dest: "/etc/cni/net.d/10-bridge.conf"
+#- name: bridge network
+#  template:
+#    src: "{{ role_path }}/templates/10-bridge.conf.j2"
+#    dest: "/etc/cni/net.d/10-bridge.conf"
 
-- name: loop back network
-  template:
-    src: "{{ role_path }}/templates/99-loopback.conf.j2"
-    dest: "/etc/cni/net.d/99-loopback.conf"
+#- name: loop back network
+#  template:
+#    src: "{{ role_path }}/templates/99-loopback.conf.j2"
+#   dest: "/etc/cni/net.d/99-loopback.conf"
 
 - name: containerd configuration
   template:

--- a/roles/worker/tasks/worker_cert.yaml
+++ b/roles/worker/tasks/worker_cert.yaml
@@ -70,11 +70,15 @@
     dest: /var/lib/kube-proxy/kubeconfig
     mode: '0755'
 
+#This option is disabled as we do not plan to use the CNI bridge network as per the 
+#Kuberenetes Hardway guide
 #- name: bridge network
 #  template:
 #    src: "{{ role_path }}/templates/10-bridge.conf.j2"
 #    dest: "/etc/cni/net.d/10-bridge.conf"
 
+#This option is disabled as we do not plan to use the CNI bridge network as per the 
+#Kuberenetes Hardway guide
 #- name: loop back network
 #  template:
 #    src: "{{ role_path }}/templates/99-loopback.conf.j2"

--- a/roles/worker/templates/kubelet-config.yaml.j2
+++ b/roles/worker/templates/kubelet-config.yaml.j2
@@ -12,8 +12,6 @@ authorization:
 clusterDomain: "cluster.local"
 clusterDNS:
   - "10.32.0.10"
-podCIDR: "{{ POD_CIDR }}"
-resolvConf: "/run/systemd/resolve/resolv.conf"
 runtimeRequestTimeout: "15m"
 tlsCertFile: "/var/lib/kubelet/{{ worker_host }}.pem"
 tlsPrivateKeyFile: "/var/lib/kubelet/{{ worker_host }}-key.pem"


### PR DESCRIPTION
Initially this cluster was build same as the "Kubernetes the Hardway" guide and, CNI bridge networking disabled to use a CNI plugin such as weave-net, calico, OVN, etc